### PR TITLE
Adds fix for potential stackoverflow

### DIFF
--- a/Forms.Core/Repositories/FormRepository.cs
+++ b/Forms.Core/Repositories/FormRepository.cs
@@ -34,6 +34,15 @@ namespace Forms.Core.Repositories
 
             form = await _cacheFramework.Get<Graph<Key, FormNode>>(formKey);
             
+            // Build the neighbors collection
+            foreach (var node in form.Nodes)
+            {
+                foreach (var neighborId in node.NeighborIds)
+                {
+                    node.Neighbors.Add(form.Nodes.FindByKey(neighborId));
+                }
+            }
+            
             // Save the graph in case it is requested later in the http request
             _forms.Add(formKey, form);
 

--- a/Graph/Graph.csproj
+++ b/Graph/Graph.csproj
@@ -4,5 +4,9 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <LangVersion>8</LangVersion>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    </ItemGroup>
     
 </Project>

--- a/Graph/Models/Graph.cs
+++ b/Graph/Models/Graph.cs
@@ -33,15 +33,18 @@ namespace Graph.Models
         public void AddDirectedEdge(GraphNode<TKey, TValue> from, GraphNode<TKey, TValue> to, int cost = 1)
         {
             from.Neighbors.Add(to);
+            from.NeighborIds.Add(to.Key);
             from.Costs.Add(cost);
         }
 
         public void AddUndirectedEdge(GraphNode<TKey, TValue> from, GraphNode<TKey, TValue> to, int cost = 1)
         {
             from.Neighbors.Add(to);
+            from.NeighborIds.Add(to.Key);
             from.Costs.Add(cost);
 
             to.Neighbors.Add(from);
+            to.NeighborIds.Add(from.Key);
             to.Costs.Add(cost);
         }
 
@@ -49,6 +52,7 @@ namespace Graph.Models
         {
             from.Costs.RemoveAt(from.Neighbors.IndexOf(to));
             from.Neighbors.Remove(to);
+            from.NeighborIds.Remove(to.Key);
         }
 
         public bool Contains(TValue value)

--- a/Graph/Models/GraphNode.cs
+++ b/Graph/Models/GraphNode.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Graph.Models
 {
@@ -9,7 +10,10 @@ namespace Graph.Models
         public GraphNode() : base() { }
         public GraphNode(TKey key, TValue value) : base(key, value) { }
         public GraphNode(TKey key, TValue value, NodeList<TKey, TValue> neighbors) : base(key, value, neighbors) { }
+        
+        [JsonIgnore]
         public new NodeList<TKey, TValue> Neighbors => base.Neighbors ?? (base.Neighbors = new NodeList<TKey, TValue>());
+        
         public List<int> Costs => _costs ??= new List<int>();
     }
 }

--- a/Graph/Models/Node.cs
+++ b/Graph/Models/Node.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
 namespace Graph.Models
 {
     public class Node<TKey, TValue>
@@ -14,6 +17,9 @@ namespace Graph.Models
         public TValue Value { get; set; }
         public TKey Key { get; set; }
 
+        [JsonIgnore]
         public NodeList<TKey, TValue> Neighbors { get; set; }
+        
+        public List<TKey> NeighborIds { get; set; } = new List<TKey>();
     }
 }


### PR DESCRIPTION
Can occur when the forms are particularly large. 

Instead of holding the neighbors directly in the cache, store their keys and build the graph using the keys.